### PR TITLE
Remove redundant part of step that is not necessary

### DIFF
--- a/worksheet.md
+++ b/worksheet.md
@@ -54,7 +54,7 @@ We're going to be using a resistor to make the balloon pop. Resistors are electr
 
 1. Inflate a balloon so it's nice and full, then tie a knot in it.
 
-1. Take 2 metres of 2-core speaker cable, and strip both ends of both cores so that the bare wire is visible. This can be done with wire strippers or, if you're very careful, with scissors: make sure that you only cut through the insulation and not the wires themselves. You can also split the two cores of the cable a little simply by pulling them apart. At one end of the cable, wrap red electrical tape around one wire (around the insulated section, not the section with the exposed core), and black electrical tape around the other. This is to label them for later.
+1. Take 2 metres of 2-core speaker cable, and strip both ends of both cores so that the bare wire is visible. This can be done with wire strippers or, if you're very careful, with scissors: make sure that you only cut through the insulation and not the wires themselves. You can also split the two cores of the cable a little simply by pulling them apart.
 
     ![](images/step1_point2_wires.jpg)
 


### PR DESCRIPTION
There is no need to wrap electrical tape around the wire. It's not necessary to label them for later as there's no instructions about this, later in the worksheet.